### PR TITLE
use external package for latex escape

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1160,6 +1160,17 @@ files = [
 ]
 
 [[package]]
+name = "pylatexenc"
+version = "2.10"
+description = "Simple LaTeX parser providing latex-to-unicode and unicode-to-latex conversion"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pylatexenc-2.10.tar.gz", hash = "sha256:3dd8fd84eb46dc30bee1e23eaab8d8fb5a7f507347b23e5f38ad9675c84f40d3"},
+]
+
+[[package]]
 name = "pypdf2"
 version = "3.0.1"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
@@ -1576,4 +1587,4 @@ test = ["covdefaults (>=2.2.2)", "coverage (>=7.1)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "3400a97860732f35248c56d738843e51b4c0c55960f50f0c7abf674d818b25d9"
+content-hash = "ea832359c98a99e666e218e183d537ec7256311808b02dec487f86104e9387be"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ python-multipart = "^0.0.5"
 httpx = "^0.23.1"
 jinja2 = "^3.1.2"
 pypdf2 = "^3.0.1"
+pylatexenc = "^2.10"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^5.0.4"

--- a/silicon/routes/sds.py
+++ b/silicon/routes/sds.py
@@ -14,6 +14,7 @@ from fastapi import (
 )
 from httpx import AsyncClient
 from pydantic import BaseModel
+from pylatexenc.latexencode import unicode_to_latex
 from sqlalchemy import func, literal_column, select
 from sqlalchemy.dialects.postgresql import insert
 from starlette.responses import StreamingResponse
@@ -21,7 +22,7 @@ from tungsten import SigmaAldrichSdsParser
 
 from silicon.constants import DEBUG, MEILI_INDEX_NAME, S3_BUCKET_NAME, S3_URL
 from silicon.models import SafetyDataSheet
-from silicon.utils.cart import fix_si, merge_pdf, tex_escape
+from silicon.utils.cart import fix_si, merge_pdf
 from silicon.utils.sds import get_sds_identifiers
 
 router = APIRouter(prefix="/sds")
@@ -165,10 +166,10 @@ async def post_checkout_sds(request: Request, req_items: list[CheckoutItem]) -> 
         else "Warning" if "Warning" in signal_words else "N/A",
         'rows': [
             [
-                tex_escape(entry['sds'].cas_number),
-                tex_escape(entry['sds'].product_name),
-                tex_escape(entry['sds'].product_brand),
-                tex_escape(entry['sds'].product_number),
+                unicode_to_latex(entry['sds'].cas_number),
+                unicode_to_latex(entry['sds'].product_name),
+                unicode_to_latex(entry['sds'].product_brand),
+                unicode_to_latex(entry['sds'].product_number),
                 fix_si(entry['mass']),
                 f'{(entry["mass"] / total_mass) * 100:.2f}\\%',
             ] for entry in entries

--- a/silicon/utils/cart.py
+++ b/silicon/utils/cart.py
@@ -1,5 +1,4 @@
 import os
-import re
 import subprocess
 from io import BytesIO
 from pathlib import Path
@@ -45,30 +44,6 @@ def merge_pdf(pdfs: list[BytesIO]) -> BytesIO:
     merger.write(bytesio)
     merger.close()
     return bytesio
-
-
-def tex_escape(text):
-    """
-        :param text: a plain text message
-        :return: the message escaped to appear correctly in LaTeX
-    """
-    conv = {
-        '&': r'\&',
-        '%': r'\%',
-        '$': r'\$',
-        '#': r'\#',
-        '_': r'\_',
-        '{': r'\{',
-        '}': r'\}',
-        '~': r'\textasciitilde{}',
-        '^': r'\^{}',
-        '\\': r'\textbackslash{}',
-        '<': r'\textless{}',
-        '>': r'\textgreater{}',
-    }
-    regex = re.compile('|'.join(re.escape(str(key))
-                                for key in sorted(conv.keys(), key=lambda item: - len(item))))
-    return regex.sub(lambda match: conv[match.group()], text)
 
 
 def fix_si(amount):


### PR DESCRIPTION
Current escape sequence system does not escape unicode characters. This cases pdflatex errors. Use an external package to escape them all into their LaTeX equivalents.